### PR TITLE
Add missing cmake command in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ git submodule update
 cd 3rdparty/nodeeditor
 mkdir BUILD
 cd BUILD
+cmake ..
 make
 ```
 


### PR DESCRIPTION
Steps in README were incorrect.

However, even with this patch I get:

```
[  2%] Building CXX object CMakeFiles/nodes.dir/src/Connection.cpp.o
spkgen/3rdparty/nodeeditor/include/nodes/internal/DataModelRegistry.hpp:14,
                 from spkgen/3rdparty/nodeeditor/include/nodes/internal/FlowScene.hpp:12,
                 from spkgen/3rdparty/nodeeditor/src/Connection.cpp:10:
spkgen/3rdparty/nodeeditor/include/nodes/internal/QStringStdHash.hpp:11:8: error: redefinition of ‘struct std::hash<QString>’
   11 | struct hash<QString>
      |        ^~~~~~~~~~~~~
In file included from /usr/include/qt/QtCore/qlist.h:47,
                 from /usr/include/qt/QtCore/qobject.h:49,
                 from /usr/include/qt/QtCore/QObject:1,
                 from spkgen/3rdparty/nodeeditor/include/nodes/internal/Connection.hpp:3,
                 from spkgen/3rdparty/nodeeditor/src/Connection.cpp:1:
/usr/include/qt/QtCore/qhashfunctions.h:204:1: note: previous definition of ‘struct std::hash<QString>’
  204 | QT_SPECIALIZE_STD_HASH_TO_CALL_QHASH_BY_CREF(QString)
      | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

Seems to be fixed in https://github.com/paceholder/nodeeditor, so I recommend to switch to that.
Looks like your fork is no longer necessary?